### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/mat.rs
+++ b/src/mat.rs
@@ -99,7 +99,7 @@ macro_rules! mat_iter {
 			type Item = &'a T;
 			type IntoIter = slice::Iter<'a, T>;
 			fn into_iter(self) -> Self::IntoIter {
-				self.data.into_iter()
+				self.data.iter()
 			}
 		}
 		impl<'a, T> IntoIterator for &'a mut $V<T> where T: Copy {

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -116,7 +116,7 @@ macro_rules! vec_iter {
 			type Item = &'a T;
 			type IntoIter = slice::Iter<'a, T>;
 			fn into_iter(self) -> Self::IntoIter {
-				self.data.into_iter()
+				self.data.iter()
 			}
 		}
 		impl<'a, T> IntoIterator for &'a mut $V<T> where T: Copy {


### PR DESCRIPTION
Use `slice::iter` instead of `into_iter` to avoid future breakage

`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.
